### PR TITLE
COMP: Explicitly link against vtkAddon following relocation of classes

### DIFF
--- a/FreeSurferImporter/MRML/CMakeLists.txt
+++ b/FreeSurferImporter/MRML/CMakeLists.txt
@@ -20,6 +20,7 @@ set(${KIT}_SRCS
 set(${KIT}_TARGET_LIBRARIES
   ${MRML_LIBRARIES}
   FreeSurfer
+  vtkAddon
   )
 
 # --------------------------------------------------------------------------

--- a/FreeSurferMarkups/MRML/CMakeLists.txt
+++ b/FreeSurferMarkups/MRML/CMakeLists.txt
@@ -21,6 +21,7 @@ set(${KIT}_TARGET_LIBRARIES
   ${MRML_LIBRARIES}
   vtkSlicerMarkupsModuleMRML
   FreeSurfer
+  vtkAddon
   )
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
After moving the classes like vtkSlicerFreeSurferDijkstraGraphGeodesicPath and vtkCurveGenerator from Slicer into vtkAddon, this commit accounts for this to avoid relying on the implicit linking from the MRMLCore target.

References:
* https://github.com/Slicer/Slicer/pull/6883
* https://github.com/Slicer/Slicer/issues/6603