### PR TITLE
COMP: VTK 9.6 Build Fix - Fix iostream include hygiene

### DIFF
--- a/FreeSurfer/vtkFSLookupTable.cxx
+++ b/FreeSurfer/vtkFSLookupTable.cxx
@@ -15,6 +15,9 @@
 // FreeSurfer includes
 #include "vtkFSLookupTable.h"
 
+// STD includes
+#include <iostream>
+
 // VTK includes
 #include <vtkObjectFactory.h>
 
@@ -47,15 +50,15 @@ void vtkFSLookupTable::PrintSelf(ostream& os, vtkIndent indent)
 {
     Superclass::PrintSelf(os, indent);
 
-    os << indent << "LowThres: " << this->LowThresh << endl;
-    os << indent << "HiThresh: " << this->HiThresh << endl;
-    os << indent << "Look up table type: " << this->GetLutTypeString() << endl;
-    os << indent << "Reverse: " << this->Reverse << endl;
-    os << indent << "Truncate: " << this->Truncate << endl;
-    os << indent << "Offset: " << this->Offset << endl;
-    os << indent << "Slope: " << this->Slope << endl;
-    os << indent << "Blufact: " << this->Blufact << endl;
-    os << indent << "Slope mid point FMid: " << this->FMid << endl;
+    os << indent << "LowThres: " << this->LowThresh << std::endl;
+    os << indent << "HiThresh: " << this->HiThresh << std::endl;
+    os << indent << "Look up table type: " << this->GetLutTypeString() << std::endl;
+    os << indent << "Reverse: " << this->Reverse << std::endl;
+    os << indent << "Truncate: " << this->Truncate << std::endl;
+    os << indent << "Offset: " << this->Offset << std::endl;
+    os << indent << "Slope: " << this->Slope << std::endl;
+    os << indent << "Blufact: " << this->Blufact << std::endl;
+    os << indent << "Slope mid point FMid: " << this->FMid << std::endl;
 }
 
 //------------------------------------------------------------------------------

--- a/FreeSurfer/vtkFSSurfaceLabelReader.cxx
+++ b/FreeSurfer/vtkFSSurfaceLabelReader.cxx
@@ -19,6 +19,9 @@
 #include <vtkFloatArray.h>
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 //-------------------------------------------------------------------------
 vtkStandardNewMacro(vtkFSSurfaceLabelReader);
 
@@ -57,7 +60,7 @@ int vtkFSSurfaceLabelReader::ReadLabel()
   // Do some basic sanity checks.
   if (output == nullptr)
     {
-    cerr << "ERROR vtkFSSurfaceLabelReader ReadLabel() : output is null" << endl;
+    std::cerr <<"ERROR vtkFSSurfaceLabelReader ReadLabel() : output is null" << std::endl;
     return this->FS_ERROR_W_OUTPUT_NULL;
     }
   vtkDebugMacro( << "vtkFSSurfaceLabelReader Execute() " << endl);
@@ -215,18 +218,18 @@ int vtkFSSurfaceLabelReader::ReadLabel()
 void vtkFSSurfaceLabelReader::PrintSelf(ostream& os, vtkIndent indent)
 {
   vtkDataReader::PrintSelf(os,indent);
-  os << indent << "Number of vertices: " << this->NumberOfVertices << endl;
-  os << indent << "Number of values in file: " << this->NumberOfValues << endl;
+  os << indent << "Number of vertices: " << this->NumberOfVertices << std::endl;
+  os << indent << "Number of values in file: " << this->NumberOfValues << std::endl;
 
-  os << indent << "Scalar array: " << endl;
+  os << indent << "Scalar array: " << std::endl;
   if (this->Scalars == nullptr)
     {
-    os << indent.GetNextIndent() << "null" << endl;
+    os << indent.GetNextIndent() << "null" << std::endl;
     }
   else
     {
-    os << indent.GetNextIndent() << "Size = " << this->Scalars->GetNumberOfTuples() << endl;
+    os << indent.GetNextIndent() << "Size = " << this->Scalars->GetNumberOfTuples() << std::endl;
     }
-  os << indent << "LabelOff: " << this->LabelOff << endl;
-  os << indent << "LabelOn: " << this->LabelOn << endl;
+  os << indent << "LabelOff: " << this->LabelOff << std::endl;
+  os << indent << "LabelOn: " << this->LabelOn << std::endl;
 }

--- a/FreeSurfer/vtkFSSurfaceReader.cxx
+++ b/FreeSurfer/vtkFSSurfaceReader.cxx
@@ -25,6 +25,9 @@
 #include <vtkPolyData.h>
 #include <vtkStreamingDemandDrivenPipeline.h>
 
+// STD includes
+#include <iostream>
+
 //-------------------------------------------------------------------------
 vtkStandardNewMacro(vtkFSSurfaceReader);
 
@@ -110,13 +113,13 @@ int vtkFSSurfaceReader::RequestData(
 #if FS_DEBUG
   switch (magicNumber) {
   case vtkFSSurfaceReader::FS_QUAD_FILE_MAGIC_NUMBER:
-    cerr << "Reading old quad file" << endl;
+    std::cerr <<"Reading old quad file" << std::endl;
     break;
   case vtkFSSurfaceReader::FS_NEW_QUAD_FILE_MAGIC_NUMBER:
-    cerr << "Reading new quad file" << endl;
+    std::cerr <<"Reading new quad file" << std::endl;
     break;
   case vtkFSSurfaceReader::FS_TRIANGLE_FILE_MAGIC_NUMBER:
-    cerr << "Reading triangle file" << endl;
+    std::cerr <<"Reading triangle file" << std::endl;
     break;
   }
 #endif
@@ -184,7 +187,7 @@ int vtkFSSurfaceReader::RequestData(
   }
 
 #if FS_DEBUG
-  cerr << numVertices << " vertices, " << numFaces * faceMultiplier << " faces" << endl;
+  std::cerr <<numVertices << " vertices, " << numFaces * faceMultiplier << " faces" << std::endl;
 #endif
 
   // If quad files, there are four vertices per face, in tri files,
@@ -345,7 +348,7 @@ int vtkFSSurfaceReader::RequestData(
   fclose (surfaceFile);
 
 #if FS_DEBUG
-  cerr << "Done reading surface." << endl;
+  std::cerr <<"Done reading surface." << std::endl;
 #endif
 
 #if FS_CALC_NORMALS

--- a/FreeSurfer/vtkFSSurfaceScalarReader.cxx
+++ b/FreeSurfer/vtkFSSurfaceScalarReader.cxx
@@ -21,6 +21,9 @@
 #include <vtkFloatArray.h>
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 //-------------------------------------------------------------------------
 vtkStandardNewMacro(vtkFSSurfaceScalarReader);
 
@@ -61,7 +64,7 @@ int vtkFSSurfaceScalarReader::ReadFSScalars()
 
   if (output == nullptr)
   {
-      cerr << "ERROR vtkFSSurfaceScalarReader ReadFSScalars() : output is null" << endl;
+      std::cerr <<"ERROR vtkFSSurfaceScalarReader ReadFSScalars() : output is null" << std::endl;
       return 0;
   }
   vtkDebugMacro( << "vtkFSSurfaceScalarReader Execute() " << endl);

--- a/FreeSurfer/vtkFSSurfaceWFileReader.cxx
+++ b/FreeSurfer/vtkFSSurfaceWFileReader.cxx
@@ -20,6 +20,9 @@
 #include <vtkFloatArray.h>
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 //-------------------------------------------------------------------------
 vtkStandardNewMacro(vtkFSSurfaceWFileReader);
 
@@ -61,7 +64,7 @@ int vtkFSSurfaceWFileReader::ReadWFile()
   // Do some basic sanity checks.
   if (output == nullptr)
     {
-    cerr << "ERROR vtkFSSurfaceWFileReader ReadWFile() : output is null" << endl;
+    std::cerr <<"ERROR vtkFSSurfaceWFileReader ReadWFile() : output is null" << std::endl;
     return this->FS_ERROR_W_OUTPUT_NULL;
     }
   vtkDebugMacro( << "vtkFSSurfaceWFileReader Execute() " << endl);

--- a/FreeSurferImporter/Logic/vtkSlicerFreeSurferImporterLogic.cxx
+++ b/FreeSurferImporter/Logic/vtkSlicerFreeSurferImporterLogic.cxx
@@ -71,6 +71,7 @@
 
 // STD includes
 #include <cassert>
+#include <iostream>
 #include <regex>
 
 //----------------------------------------------------------------------------

--- a/FreeSurferImporter/MRML/vtkFreeSurferCurveGenerator.cxx
+++ b/FreeSurferImporter/MRML/vtkFreeSurferCurveGenerator.cxx
@@ -25,6 +25,9 @@
 
 #include <vtkMRMLNode.h>
 
+// STD includes
+#include <iostream>
+
 //------------------------------------------------------------------------------
 vtkStandardNewMacro(vtkFreeSurferCurveGenerator);
 

--- a/FreeSurferImporter/MRML/vtkMRMLFreeSurferModelOverlayStorageNode.cxx
+++ b/FreeSurferImporter/MRML/vtkMRMLFreeSurferModelOverlayStorageNode.cxx
@@ -43,6 +43,7 @@ Version:   $Revision: 1.2 $
 // ITKSys includes
 
 // STD includes
+#include <iostream>
 
 // Initialize static member that controls resampling --
 // old comment: "This offset will be changed to 0.5 from 0.0 per 2/8/2002 Slicer
@@ -271,7 +272,7 @@ bool vtkMRMLFreeSurferModelOverlayStorageNode::ReadScalarOverlayAnnot(const std:
       numNames++;
       std::string colorName = colorString.substr(startBracketIndex+1, endBracketIndex - startBracketIndex - 1);
       vtkDebugMacro("Adding color name = " << colorName.c_str() << " at index \""
-        << colorIndexString.c_str() << "\"" << ", as int: " << atoi(colorIndexString.c_str()) <<  endl);
+        << colorIndexString.c_str() << "\"" << ", as int: " << atoi(colorIndexString.c_str()) << endl);
       if (lutNode->SetColorName(atoi(colorIndexString.c_str()), colorName.c_str()) == 0)
         {
         vtkErrorMacro("ReadData: error setting annotation color name " << colorName.c_str()

--- a/FreeSurferImporter/MRML/vtkMRMLFreeSurferProceduralColorNode.cxx
+++ b/FreeSurferImporter/MRML/vtkMRMLFreeSurferProceduralColorNode.cxx
@@ -11,6 +11,7 @@ Date:      $Date: 2006/03/03 22:26:39 $
 Version:   $Revision: 1.0 $
 
 =========================================================================auto=*/
+#include <iostream>
 #include <sstream>
 #include <vtksys/SystemTools.hxx>
 

--- a/FreeSurferMarkups/MRML/vtkFreeSurferCurveGenerator.cxx
+++ b/FreeSurferMarkups/MRML/vtkFreeSurferCurveGenerator.cxx
@@ -25,6 +25,9 @@
 
 #include <vtkMRMLNode.h>
 
+// STD includes
+#include <iostream>
+
 //------------------------------------------------------------------------------
 vtkStandardNewMacro(vtkFreeSurferCurveGenerator);
 

--- a/FreeSurferMarkups/MRML/vtkSlicerFreeSurferDijkstraGraphGeodesicPath.cxx
+++ b/FreeSurferMarkups/MRML/vtkSlicerFreeSurferDijkstraGraphGeodesicPath.cxx
@@ -28,6 +28,9 @@
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
 
+// STD includes
+#include <iostream>
+
 //------------------------------------------------------------------------------
 vtkStandardNewMacro(vtkSlicerFreeSurferDijkstraGraphGeodesicPath);
 


### PR DESCRIPTION
Add explicit #include <iostream> to 12 C++ files that use iostream symbols (std::cerr, std::endl, std::ostream) without the include. Prefix all unqualified cerr/endl uses with std:: in 9 files.

See: https://discourse.vtk.org/t/important-update-standard-iostream-availability-from-vtk/16171