### PR TITLE
BUG: Guard intermediate logic pointers in FreeSurferMarkups setup()

### DIFF
--- a/FreeSurferMarkups/qSlicerFreeSurferMarkupsModule.cxx
+++ b/FreeSurferMarkups/qSlicerFreeSurferMarkupsModule.cxx
@@ -30,6 +30,8 @@
 #include <vtkMRMLThreeDViewDisplayableManagerFactory.h>
 
 // MRML includes
+#include <vtkMRMLAbstractLogic.h>
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLMarkupsFreeSurferCurveNode.h>
 
 // Logic includes
@@ -117,7 +119,15 @@ void qSlicerFreeSurferMarkupsModule::setup()
 {
   this->Superclass::setup();
 
-  vtkSlicerMarkupsLogic* markupsLogic = vtkSlicerMarkupsLogic::SafeDownCast(this->logic()->GetMRMLApplicationLogic()->GetModuleLogic("Markups"));
+  vtkMRMLAbstractLogic* moduleLogic = this->logic();
+  vtkMRMLApplicationLogic* appLogic = moduleLogic ? moduleLogic->GetMRMLApplicationLogic() : nullptr;
+  if (!appLogic)
+  {
+    qCritical("Could not find application logic");
+    return;
+  }
+
+  vtkSlicerMarkupsLogic* markupsLogic = vtkSlicerMarkupsLogic::SafeDownCast(appLogic->GetModuleLogic("Markups"));
   if (!markupsLogic)
   {
     qCritical("Could not find Markups logic");


### PR DESCRIPTION
Guard the intermediate logic pointers in `qSlicerFreeSurferMarkupsModule::setup()` so instantiating the module without a full application logs a diagnostic and returns instead of segfaulting.

<details>
<summary>Root cause</summary>

`setup()` dereferenced a three-hop chain and only null-checked the final result:

```cpp
vtkSlicerMarkupsLogic* markupsLogic = vtkSlicerMarkupsLogic::SafeDownCast(
    this->logic()->GetMRMLApplicationLogic()->GetModuleLogic("Markups"));
if (!markupsLogic) { qCritical("Could not find Markups logic"); return; }
```

When the module is instantiated outside a fully-initialized application,
`GetMRMLApplicationLogic()` returns `nullptr`, so `GetModuleLogic()` is invoked
on a null pointer and the process **SIGSEGVs before the existing guard runs**.

This is exactly what the auto-generated
`qSlicerFreeSurferMarkupsModuleWidgetGenericTest` does — it builds a minimal
`qSlicerApplication` that does not wire the module-logic graph. The crash also
leaves a persistent macOS "reopen windows?" dialog that can block an unattended
build.

</details>

<details>
<summary>Fix</summary>

Split the chain and check each intermediate, matching the guard style already
used in `vtkSlicerGridSurfaceMarkupsLogic::RegisterNodes()`:

```cpp
vtkMRMLAbstractLogic* moduleLogic = this->logic();
vtkMRMLApplicationLogic* appLogic = moduleLogic ? moduleLogic->GetMRMLApplicationLogic() : nullptr;
if (!appLogic) { qCritical("Could not find application logic"); return; }

vtkSlicerMarkupsLogic* markupsLogic = vtkSlicerMarkupsLogic::SafeDownCast(appLogic->GetModuleLogic("Markups"));
if (!markupsLogic) { qCritical("Could not find Markups logic"); return; }
```

Adds explicit includes for the two types now named directly
(`vtkMRMLAbstractLogic.h`, `vtkMRMLApplicationLogic.h`).

</details>

<details>
<summary>Verification</summary>

Built against 3D Slicer (ITK 6 / Qt 6.9.1). Before: `qSlicerFreeSurferMarkupsModuleWidgetGenericTest`
terminated with SIGSEGV in `vtkMRMLApplicationLogic::GetModuleLogic()`. After:
the test exits cleanly (no signal) and prints:

```
Could not find application logic
```

The module can only be meaningfully exercised inside the full Slicer application
(where the logic graph is valid); this change ensures the standalone harness
fails gracefully rather than crashing.

</details>

<!--
provenance: claude-code session 2026-07-23
target: PerkLab/SlicerFreeSurfer @ master (base 6af71da)
branch: fix-freesurfermarkups-setup-null-guard  commit c401663
related: sibling modules with the same multi-hop-logic-lookup pattern (e.g. other
  Markups-derived modules) may warrant the same guard; ModelClip crashes via a
  different path (ctkLayoutFactory::threeDWidget, not GetModuleLogic).
-->
